### PR TITLE
feat(arch): add ppc64le

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -40,7 +40,7 @@ if [[ -z "$DOCKER_IMAGE_VERSION" ]]; then
 fi
 
 export SOURCE="https://github.com/${GITHUB_REPOSITORY}"
-platforms="linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+platforms="linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le"
 
 # Login to Docker Hub
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin "docker.io"


### PR DESCRIPTION
## Description
[Containerd 1.8.6](https://github.com/containerd/containerd/releases/tag/v1.6.8) supports `ppc64le` arch.
I am using this image.
It would be cool, if `ppc64le` arch was added.

@westonsteimel can you take a look on this?
Thanks in advance!

Best Regards, Dmitriy